### PR TITLE
Mark the kscan node as wakeup source

### DIFF
--- a/boards/shields/TOTEM/TOTEM.dtsi
+++ b/boards/shields/TOTEM/TOTEM.dtsi
@@ -29,8 +29,9 @@
 
     kscan0: kscan_0 {
         compatible = "zmk,kscan-gpio-matrix";      
+        wakeup-source;
+
         diode-direction = "col2row"; 
-        
         row-gpios
             = <&xiao_d 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&xiao_d 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>


### PR DESCRIPTION
Allows the keyboard to wake up from deep sleep (if enabled at compile time).

Reference:
- https://zmk.dev/docs/config/power#kconfig
- zmkfirmware/zmk@fff1cbecdcc75302b6280a469ed31687cfc79776